### PR TITLE
feat: redesign header with sunset theme

### DIFF
--- a/finish-it-react/src/App.tsx
+++ b/finish-it-react/src/App.tsx
@@ -156,9 +156,8 @@ const App: React.FC = () => {
   }, [activeTaskId, titleInput, minutesInput, addTask, togglePause, completeTask, giveUpTask, focusMode]);
 
   const completedTasks = tasks.filter(t => t.status === 'done').length;
-  const activeTasks = tasks.filter(t => t.status === 'active').length;
-  const pendingTasks = tasks.filter(t => t.status === 'pending').length;
-  const failedTasks = tasks.filter(t => t.status === 'failed').length;
+    const activeTasks = tasks.filter(t => t.status === 'active').length;
+    const failedTasks = tasks.filter(t => t.status === 'failed').length;
 
   return (
     <div className="min-h-screen relative overflow-hidden">
@@ -174,22 +173,22 @@ const App: React.FC = () => {
       <div className="relative z-10 min-h-screen p-6">
 
         {/* Floating Header */}
-        <div className="max-w-7xl mx-auto mb-12">
-          <div className="glass-soft rounded-3xl p-8 fade-in-up">
-            <div className="text-center mb-8">
-              <div className="inline-flex items-center justify-center w-20 h-20 rounded-full mb-6"
-                style={{ background: 'linear-gradient(135deg, #667eea, #764ba2)' }}>
-                <svg className="w-10 h-10 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
-                </svg>
+          <div className="max-w-7xl mx-auto mb-12">
+            <div className="glass-soft rounded-3xl p-8 fade-in-up">
+              <div className="text-center mb-8">
+                <div className="inline-flex items-center justify-center w-20 h-20 rounded-full mb-6"
+                  style={{ background: 'linear-gradient(135deg, #ff9a9e, #fecfef)' }}>
+                  <svg className="w-10 h-10 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
+                  </svg>
+                </div>
+                <h1 className="text-5xl md:text-7xl font-black mb-4 bg-gradient-to-r from-orange-400 via-pink-500 to-purple-600 bg-clip-text text-transparent">
+                  TaskTimer Zen
+                </h1>
+                <p className="text-xl text-gray-700 max-w-2xl mx-auto">
+                  A vibrant space to track and celebrate your progress
+                </p>
               </div>
-              <h1 className="text-5xl md:text-7xl font-black mb-4 bg-gradient-to-r from-purple-600 via-blue-600 to-cyan-500 bg-clip-text text-transparent">
-                Flow Focus
-              </h1>
-              <p className="text-xl text-gray-600 max-w-2xl mx-auto">
-                Beautiful productivity in perfect harmony
-              </p>
-            </div>
 
             {/* Task Creation */}
             <div className="max-w-4xl mx-auto">

--- a/finish-it-react/src/App.tsx
+++ b/finish-it-react/src/App.tsx
@@ -97,12 +97,21 @@ const App: React.FC = () => {
   }, [startTimer]);
 
   const togglePause = useCallback((id: string) => {
-    setTasks((prevTasks) =>
-      prevTasks.map((task) =>
-        task.id === id ? { ...task, paused: !task.paused } : task
-      )
+    const task = tasks.find(t => t.id === id);
+    if (!task) return;
+    const newPaused = !task.paused;
+    setTasks(prev =>
+      prev.map(t => (t.id === id ? { ...t, paused: newPaused } : t))
     );
-  }, []);
+    if (id === activeTaskId) {
+      if (newPaused) {
+        stopTimer();
+      } else {
+        lastTickTimeRef.current = Date.now();
+        startTimer();
+      }
+    }
+  }, [tasks, activeTaskId, stopTimer, startTimer]);
 
   const completeTask = useCallback((id: string, victoryNote: string = '') => {
     setTasks((prevTasks) =>
@@ -177,37 +186,37 @@ const App: React.FC = () => {
             <div className="glass-soft rounded-3xl p-8 fade-in-up">
               <div className="text-center mb-8">
                 <div className="inline-flex items-center justify-center w-20 h-20 rounded-full mb-6"
-                  style={{ background: 'linear-gradient(135deg, #ff9a9e, #fecfef)' }}>
+                  style={{ background: 'linear-gradient(135deg, #16a34a, #1e293b)' }}>
                   <svg className="w-10 h-10 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
                   </svg>
                 </div>
-                <h1 className="text-5xl md:text-7xl font-black mb-4 bg-gradient-to-r from-orange-400 via-pink-500 to-purple-600 bg-clip-text text-transparent">
-                  TaskTimer Zen
+                <h1 className="text-5xl md:text-7xl font-black mb-4 bg-gradient-to-r from-green-400 via-emerald-600 to-gray-900 bg-clip-text text-transparent">
+                  TaskTimer Slayer
                 </h1>
-                <p className="text-xl text-gray-700 max-w-2xl mx-auto">
-                  A vibrant space to track and celebrate your progress
+                <p className="text-xl text-gray-200 max-w-2xl mx-auto">
+                  Forge your Nichirin and conquer your to-do demons
                 </p>
               </div>
-
+            
             {/* Task Creation */}
             <div className="max-w-4xl mx-auto">
               <div className="grid grid-cols-1 md:grid-cols-12 gap-6 items-end">
                 <div className="md:col-span-7">
-                  <label className="block text-sm font-semibold text-gray-700 mb-3">
-                    What beautiful thing will you create?
+                  <label className="block text-sm font-semibold text-gray-200 mb-3">
+                    What demon will you slay?
                   </label>
                   <input
                     id="task-input"
                     type="text"
-                    placeholder="Design the perfect interface..."
+                    placeholder="Track down the next foe..."
                     value={titleInput}
                     onChange={(e) => setTitleInput(e.target.value)}
                     className="input-soft w-full"
                   />
                 </div>
                 <div className="md:col-span-2">
-                  <label className="block text-sm font-semibold text-gray-700 mb-3">
+                  <label className="block text-sm font-semibold text-gray-200 mb-3">
                     Focus time
                   </label>
                   <input
@@ -224,7 +233,7 @@ const App: React.FC = () => {
                     onClick={addTask}
                     className="btn-soft btn-primary w-full"
                   >
-                    ✨ Begin Journey
+                    ⚔️ Begin Hunt
                   </button>
                 </div>
               </div>
@@ -239,22 +248,22 @@ const App: React.FC = () => {
               <div className="grid grid-cols-2 md:grid-cols-4 gap-6 text-center">
                 <div className="space-y-2">
                   <div className="text-4xl font-black text-purple-600">{tasks.length}</div>
-                  <div className="text-sm font-medium text-gray-600">Total Dreams</div>
+                  <div className="text-sm font-medium text-gray-300">Total Missions</div>
                   <div className="status-dot status-pending mx-auto"></div>
                 </div>
                 <div className="space-y-2">
                   <div className="text-4xl font-black text-green-500">{completedTasks}</div>
-                  <div className="text-sm font-medium text-gray-600">Achieved</div>
+                  <div className="text-sm font-medium text-gray-300">Slain</div>
                   <div className="status-dot status-done mx-auto"></div>
                 </div>
                 <div className="space-y-2">
                   <div className="text-4xl font-black text-blue-500">{activeTasks}</div>
-                  <div className="text-sm font-medium text-gray-600">In Flow</div>
+                  <div className="text-sm font-medium text-gray-300">Engaged</div>
                   <div className="status-dot status-active mx-auto"></div>
                 </div>
                 <div className="space-y-2">
                   <div className="text-4xl font-black text-red-400">{failedTasks}</div>
-                  <div className="text-sm font-medium text-gray-600">Learning</div>
+                  <div className="text-sm font-medium text-gray-300">Retreated</div>
                   <div className="status-dot status-failed mx-auto"></div>
                 </div>
               </div>
@@ -268,14 +277,14 @@ const App: React.FC = () => {
             <div className="text-center py-20">
               <div className="glass-card rounded-3xl p-16 max-w-2xl mx-auto fade-in-up">
                 <div className="w-32 h-32 mx-auto mb-8 rounded-full flex items-center justify-center"
-                  style={{ background: 'linear-gradient(135deg, #a8edea, #fed6e3)' }}>
+                  style={{ background: 'linear-gradient(135deg, #16a34a, #dc2626)' }}>
                   <svg className="w-16 h-16 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
                   </svg>
                 </div>
-                <h3 className="text-3xl font-bold mb-4 text-gray-800">Ready to Flow?</h3>
-                <p className="text-xl text-gray-600 leading-relaxed">
-                  Create your first beautiful task and enter the zone of pure productivity
+                <h3 className="text-3xl font-bold mb-4 text-gray-100">Ready to Hunt?</h3>
+                <p className="text-xl text-gray-300 leading-relaxed">
+                  Forge your first mission and join the Corps
                 </p>
               </div>
             </div>

--- a/finish-it-react/src/components/TaskCard.tsx
+++ b/finish-it-react/src/components/TaskCard.tsx
@@ -13,32 +13,32 @@ interface TaskCardProps {
 
 const TaskCard: React.FC<TaskCardProps> = ({ task, onStart, onDone, onGiveUp, onTogglePause, isActive }) => {
   const handleDone = () => {
-    const note = window.prompt('✨ How does it feel to complete this beautiful task?') || '';
+    const note = window.prompt('🔥 How does it feel to finish this mission?') || '';
     onDone(task.id, note);
   };
 
   const getGradientByStatus = () => {
     switch (task.status) {
       case 'pending':
-        return 'linear-gradient(135deg, #a8edea 0%, #fed6e3 100%)';
+        return 'linear-gradient(135deg, #16a34a 0%, #1e293b 100%)';
       case 'active':
-        return 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)';
+        return 'linear-gradient(135deg, #dc2626 0%, #7f1d1d 100%)';
       case 'done':
-        return 'linear-gradient(135deg, #48bb78 0%, #38a169 100%)';
+        return 'linear-gradient(135deg, #fbbf24 0%, #f87171 100%)';
       case 'failed':
-        return 'linear-gradient(135deg, #f56565 0%, #e53e3e 100%)';
+        return 'linear-gradient(135deg, #4b5563 0%, #1f2937 100%)';
       default:
-        return 'linear-gradient(135deg, #a8edea 0%, #fed6e3 100%)';
+        return 'linear-gradient(135deg, #16a34a 0%, #1e293b 100%)';
     }
   };
 
   const getStatusEmoji = () => {
     switch (task.status) {
-      case 'pending': return '🌸';
-      case 'active': return task.paused ? '⏸️' : '✨';
-      case 'done': return '🎉';
-      case 'failed': return '💫';
-      default: return '🌸';
+      case 'pending': return '🎴';
+      case 'active': return task.paused ? '⏸️' : '💥';
+      case 'done': return '🔥';
+      case 'failed': return '💀';
+      default: return '🎴';
     }
   };
 
@@ -63,20 +63,20 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, onStart, onDone, onGiveUp, on
           <div className="flex items-center mb-3">
             <span className="text-3xl mr-3">{getStatusEmoji()}</span>
             <div className="flex flex-col">
-              <span className="text-xs font-semibold text-gray-500 uppercase tracking-wider">
+              <span className="text-xs font-semibold text-gray-400 uppercase tracking-wider">
                 {task.status}
               </span>
               {task.status === 'active' && (
-                <span className="text-xs text-purple-600 font-medium">
+                <span className="text-xs text-green-400 font-medium">
                   {getTimeRemaining()} remaining
                 </span>
               )}
             </div>
           </div>
-          <h3 className="text-2xl font-bold text-gray-800 leading-tight mb-2">
+          <h3 className="text-2xl font-bold text-gray-100 leading-tight mb-2">
             {task.title}
           </h3>
-          <div className="flex items-center text-sm text-gray-500 space-x-3">
+          <div className="flex items-center text-sm text-gray-400 space-x-3">
             <div className="flex items-center">
               <svg className="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
@@ -107,7 +107,7 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, onStart, onDone, onGiveUp, on
               <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.828 14.828a4 4 0 01-5.656 0M9 10h1m4 0h1m-6 4h8m-9-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
-              <span>Enter Flow State</span>
+              <span>Begin Mission</span>
             </span>
           </button>
         )}
@@ -124,14 +124,14 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, onStart, onDone, onGiveUp, on
                     <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.828 14.828a4 4 0 01-5.656 0M9 10h1m4 0h1m-6 4h8m-9-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                     </svg>
-                    <span>Resume Flow</span>
+                    <span>Resume Hunt</span>
                   </>
                 ) : (
                   <>
                     <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 9v6m4-6v6m7-3a9 9 0 11-18 0 9 9 0 0118 0z" />
                     </svg>
-                    <span>Pause Flow</span>
+                    <span>Pause Hunt</span>
                   </>
                 )}
               </span>
@@ -146,7 +146,7 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, onStart, onDone, onGiveUp, on
                   <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
                   </svg>
-                  <span>Complete</span>
+                  <span>Victory</span>
                 </span>
               </button>
               <button
@@ -157,7 +157,7 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, onStart, onDone, onGiveUp, on
                   <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
                   </svg>
-                  <span>Release</span>
+                  <span>Retreat</span>
                 </span>
               </button>
             </div>
@@ -167,16 +167,16 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, onStart, onDone, onGiveUp, on
         {task.status === 'done' && (
           <div className="text-center py-6">
             <div className="w-20 h-20 mx-auto mb-4 rounded-full flex items-center justify-center"
-                 style={{background: 'linear-gradient(135deg, #48bb78, #38a169)'}}>
+                 style={{background: 'linear-gradient(135deg, #fbbf24, #f87171)'}}>
               <svg className="w-10 h-10 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
               </svg>
             </div>
-            <h4 className="text-xl font-bold text-green-600 mb-2">Beautiful Work!</h4>
-            <p className="text-gray-600">You've achieved something wonderful</p>
+            <h4 className="text-xl font-bold text-yellow-400 mb-2">Flawless Victory!</h4>
+            <p className="text-gray-300">You've completed this mission</p>
             {task.victoryNote && (
-              <div className="mt-4 p-4 bg-green-50 rounded-2xl border border-green-200">
-                <p className="text-sm text-green-700 italic">"{task.victoryNote}"</p>
+              <div className="mt-4 p-4 bg-yellow-50 rounded-2xl border border-yellow-200">
+                <p className="text-sm text-yellow-700 italic">"{task.victoryNote}"</p>
               </div>
             )}
           </div>
@@ -185,26 +185,26 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, onStart, onDone, onGiveUp, on
         {task.status === 'failed' && (
           <div className="text-center py-6">
             <div className="w-20 h-20 mx-auto mb-4 rounded-full flex items-center justify-center"
-                 style={{background: 'linear-gradient(135deg, #f56565, #e53e3e)'}}>
+                 style={{background: 'linear-gradient(135deg, #4b5563, #1f2937)'}}>
               <svg className="w-10 h-10 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
               </svg>
             </div>
-            <h4 className="text-xl font-bold text-red-500 mb-2">Learning Moment</h4>
-            <p className="text-gray-600">Every attempt makes you stronger</p>
+            <h4 className="text-xl font-bold text-gray-400 mb-2">A Setback</h4>
+            <p className="text-gray-300">Every attempt makes you stronger</p>
           </div>
         )}
       </div>
 
-      {/* Active Flow Indicator */}
+      {/* Active Hunt Indicator */}
       {isActive && task.status === 'active' && (
-        <div className="mt-6 flex items-center justify-center space-x-3 text-purple-600">
+        <div className="mt-6 flex items-center justify-center space-x-3 text-green-500">
           <div className="flex space-x-1">
-            <div className="w-2 h-2 bg-purple-500 rounded-full animate-bounce" style={{ animationDelay: '0ms' }}></div>
-            <div className="w-2 h-2 bg-purple-500 rounded-full animate-bounce" style={{ animationDelay: '150ms' }}></div>
-            <div className="w-2 h-2 bg-purple-500 rounded-full animate-bounce" style={{ animationDelay: '300ms' }}></div>
+            <div className="w-2 h-2 bg-green-400 rounded-full animate-bounce" style={{ animationDelay: '0ms' }}></div>
+            <div className="w-2 h-2 bg-green-400 rounded-full animate-bounce" style={{ animationDelay: '150ms' }}></div>
+            <div className="w-2 h-2 bg-green-400 rounded-full animate-bounce" style={{ animationDelay: '300ms' }}></div>
           </div>
-          <span className="text-sm font-medium">In beautiful flow</span>
+          <span className="text-sm font-medium">On the hunt</span>
         </div>
       )}
     </div>

--- a/finish-it-react/src/index.css
+++ b/finish-it-react/src/index.css
@@ -1,31 +1,31 @@
 @import "tailwindcss";
 
-/* Beautiful Soft Bright Theme */
+/* Demon Slayer Inspired Theme */
 :root {
-  --gradient-primary: linear-gradient(135deg, #ff9a9e 0%, #fecfef 100%);
-  --gradient-soft: linear-gradient(135deg, #a1c4fd 0%, #c2e9fb 100%);
-  --gradient-warm: linear-gradient(135deg, #f6d365 0%, #fda085 100%);
-  --gradient-cool: linear-gradient(135deg, #84fab0 0%, #8fd3f4 100%);
-  --gradient-purple: linear-gradient(135deg, #fad0c4 0%, #ffd1ff 100%);
-  --gradient-blue: linear-gradient(135deg, #a0c0ff 0%, #90f7ec 100%);
+  --gradient-primary: linear-gradient(135deg, #16a34a 0%, #1e293b 100%);
+  --gradient-soft: linear-gradient(135deg, #dc2626 0%, #7f1d1d 100%);
+  --gradient-warm: linear-gradient(135deg, #fbbf24 0%, #f87171 100%);
+  --gradient-cool: linear-gradient(135deg, #3b82f6 0%, #1e3a8a 100%);
+  --gradient-purple: linear-gradient(135deg, #a855f7 0%, #6b21a8 100%);
+  --gradient-blue: linear-gradient(135deg, #0ea5e9 0%, #1e40af 100%);
 }
 
 @theme {
-  --color-bg: #fafbff;
-  --color-bg-secondary: #ffffff;
-  --color-bg-tertiary: #f8fafc;
-  --color-ink: #2d3748;
-  --color-muted: #718096;
-  --color-accent: #667eea;
-  --color-accent2: #764ba2;
-  --color-accent3: #89f7fe;
-  --color-good: #48bb78;
-  --color-bad: #f56565;
-  --color-warning: #ed8936;
-  --color-soft-pink: #fed6e3;
-  --color-soft-blue: #a8edea;
-  --color-soft-purple: #d299c2;
-  --color-soft-yellow: #fef9d7;
+  --color-bg: #0f172a;
+  --color-bg-secondary: #1e293b;
+  --color-bg-tertiary: #334155;
+  --color-ink: #e2e8f0;
+  --color-muted: #94a3b8;
+  --color-accent: #16a34a;
+  --color-accent2: #dc2626;
+  --color-accent3: #3b82f6;
+  --color-good: #16a34a;
+  --color-bad: #dc2626;
+  --color-warning: #fbbf24;
+  --color-soft-pink: #fecdd3;
+  --color-soft-blue: #bfdbfe;
+  --color-soft-purple: #c4b5fd;
+  --color-soft-yellow: #fef9c3;
 }
 
 * {
@@ -41,8 +41,13 @@ body,
 
 body {
   margin: 0;
-  background: linear-gradient(120deg, #f6d365 0%, #fda085 100%);
-  color: #2d3748;
+  background-color: #000;
+  background-image:
+    linear-gradient(45deg, #16a34a 25%, transparent 25%, transparent 75%, #16a34a 75%),
+    linear-gradient(45deg, #16a34a 25%, transparent 25%, transparent 75%, #16a34a 75%);
+  background-size: 40px 40px;
+  background-position: 0 0, 20px 20px;
+  color: #e2e8f0;
   overflow-x: hidden;
 }
 
@@ -69,7 +74,7 @@ body {
 .orb-1 {
   width: 400px;
   height: 400px;
-  background: radial-gradient(circle, rgba(255, 154, 158, 0.3), transparent 70%);
+  background: radial-gradient(circle, rgba(22, 163, 74, 0.25), transparent 70%);
   top: -10%;
   left: -10%;
   animation-delay: 0s;
@@ -78,7 +83,7 @@ body {
 .orb-2 {
   width: 300px;
   height: 300px;
-  background: radial-gradient(circle, rgba(255, 183, 178, 0.3), transparent 70%);
+  background: radial-gradient(circle, rgba(220, 38, 38, 0.25), transparent 70%);
   top: 20%;
   right: -5%;
   animation-delay: -7s;
@@ -87,7 +92,7 @@ body {
 .orb-3 {
   width: 250px;
   height: 250px;
-  background: radial-gradient(circle, rgba(255, 218, 185, 0.3), transparent 70%);
+  background: radial-gradient(circle, rgba(59, 130, 246, 0.25), transparent 70%);
   bottom: 10%;
   left: 20%;
   animation-delay: -14s;
@@ -96,7 +101,7 @@ body {
 .orb-4 {
   width: 350px;
   height: 350px;
-  background: radial-gradient(circle, rgba(241, 158, 194, 0.3), transparent 70%);
+  background: radial-gradient(circle, rgba(234, 179, 8, 0.25), transparent 70%);
   bottom: -10%;
   right: 10%;
   animation-delay: -21s;
@@ -185,36 +190,36 @@ body {
 }
 
 .btn-primary {
-  background: linear-gradient(135deg, #667eea, #764ba2);
+  background: linear-gradient(135deg, #16a34a, #1e293b);
   color: white;
-  box-shadow: 0 10px 30px rgba(102, 126, 234, 0.3);
+  box-shadow: 0 10px 30px rgba(22, 163, 74, 0.3);
 }
 
 .btn-primary:hover {
   transform: translateY(-3px);
-  box-shadow: 0 15px 40px rgba(102, 126, 234, 0.4);
+  box-shadow: 0 15px 40px rgba(22, 163, 74, 0.4);
 }
 
 .btn-success {
-  background: linear-gradient(135deg, #48bb78, #38a169);
+  background: linear-gradient(135deg, #fbbf24, #f87171);
   color: white;
-  box-shadow: 0 10px 30px rgba(72, 187, 120, 0.3);
+  box-shadow: 0 10px 30px rgba(251, 191, 36, 0.3);
 }
 
 .btn-success:hover {
   transform: translateY(-3px);
-  box-shadow: 0 15px 40px rgba(72, 187, 120, 0.4);
+  box-shadow: 0 15px 40px rgba(251, 191, 36, 0.4);
 }
 
 .btn-danger {
-  background: linear-gradient(135deg, #f56565, #e53e3e);
+  background: linear-gradient(135deg, #4b5563, #1f2937);
   color: white;
-  box-shadow: 0 10px 30px rgba(245, 101, 101, 0.3);
+  box-shadow: 0 10px 30px rgba(55, 65, 81, 0.3);
 }
 
 .btn-danger:hover {
   transform: translateY(-3px);
-  box-shadow: 0 15px 40px rgba(245, 101, 101, 0.4);
+  box-shadow: 0 15px 40px rgba(55, 65, 81, 0.4);
 }
 
 .btn-soft-secondary {

--- a/finish-it-react/src/index.css
+++ b/finish-it-react/src/index.css
@@ -2,12 +2,12 @@
 
 /* Beautiful Soft Bright Theme */
 :root {
-  --gradient-primary: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  --gradient-soft: linear-gradient(135deg, #a8edea 0%, #fed6e3 100%);
-  --gradient-warm: linear-gradient(135deg, #ffecd2 0%, #fcb69f 100%);
-  --gradient-cool: linear-gradient(135deg, #a8edea 0%, #fed6e3 100%);
-  --gradient-purple: linear-gradient(135deg, #d299c2 0%, #fef9d7 100%);
-  --gradient-blue: linear-gradient(135deg, #89f7fe 0%, #66a6ff 100%);
+  --gradient-primary: linear-gradient(135deg, #ff9a9e 0%, #fecfef 100%);
+  --gradient-soft: linear-gradient(135deg, #a1c4fd 0%, #c2e9fb 100%);
+  --gradient-warm: linear-gradient(135deg, #f6d365 0%, #fda085 100%);
+  --gradient-cool: linear-gradient(135deg, #84fab0 0%, #8fd3f4 100%);
+  --gradient-purple: linear-gradient(135deg, #fad0c4 0%, #ffd1ff 100%);
+  --gradient-blue: linear-gradient(135deg, #a0c0ff 0%, #90f7ec 100%);
 }
 
 @theme {
@@ -41,7 +41,7 @@ body,
 
 body {
   margin: 0;
-  background: linear-gradient(135deg, #fafbff 0%, #f0f4ff 50%, #e6f3ff 100%);
+  background: linear-gradient(120deg, #f6d365 0%, #fda085 100%);
   color: #2d3748;
   overflow-x: hidden;
 }
@@ -69,7 +69,7 @@ body {
 .orb-1 {
   width: 400px;
   height: 400px;
-  background: radial-gradient(circle, rgba(102, 126, 234, 0.3), transparent 70%);
+  background: radial-gradient(circle, rgba(255, 154, 158, 0.3), transparent 70%);
   top: -10%;
   left: -10%;
   animation-delay: 0s;
@@ -78,7 +78,7 @@ body {
 .orb-2 {
   width: 300px;
   height: 300px;
-  background: radial-gradient(circle, rgba(168, 237, 234, 0.3), transparent 70%);
+  background: radial-gradient(circle, rgba(255, 183, 178, 0.3), transparent 70%);
   top: 20%;
   right: -5%;
   animation-delay: -7s;
@@ -87,7 +87,7 @@ body {
 .orb-3 {
   width: 250px;
   height: 250px;
-  background: radial-gradient(circle, rgba(254, 214, 227, 0.3), transparent 70%);
+  background: radial-gradient(circle, rgba(255, 218, 185, 0.3), transparent 70%);
   bottom: 10%;
   left: 20%;
   animation-delay: -14s;
@@ -96,7 +96,7 @@ body {
 .orb-4 {
   width: 350px;
   height: 350px;
-  background: radial-gradient(circle, rgba(210, 153, 194, 0.3), transparent 70%);
+  background: radial-gradient(circle, rgba(241, 158, 194, 0.3), transparent 70%);
   bottom: -10%;
   right: 10%;
   animation-delay: -21s;


### PR DESCRIPTION
## Summary
- Revamp app header with "TaskTimer Zen" branding and vivid orange–pink gradient
- Introduce sunset-inspired palette and matching floating orb accents
- Clean up unused task counter to satisfy lint rules

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6d93f877c832da32ecc8b65454e24